### PR TITLE
remove calls to `bottle: unneeded` as it is now deprecated

### DIFF
--- a/Formula/gopaniccheck.rb
+++ b/Formula/gopaniccheck.rb
@@ -3,7 +3,6 @@ class Gopaniccheck < Formula
   desc "Go Panic Check"
   homepage "https://github.com/bflad/gopaniccheck"
   version "0.1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/bflad/gopaniccheck/releases/download/v0.1.0/gopaniccheck_0.1.0_darwin_amd64.tar.gz"

--- a/Formula/tfproviderdocs.rb
+++ b/Formula/tfproviderdocs.rb
@@ -6,7 +6,6 @@ class Tfproviderdocs < Formula
   desc "Terraform Provider Documentation Tool"
   homepage "https://github.com/bflad/tfproviderdocs"
   version "0.9.1"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/bflad/tfproviderdocs/releases/download/v0.9.1/tfproviderdocs_0.9.1_darwin_amd64.tar.gz"

--- a/Formula/tfproviderlint.rb
+++ b/Formula/tfproviderlint.rb
@@ -6,7 +6,6 @@ class Tfproviderlint < Formula
   desc "Terraform Provider Linter"
   homepage "https://github.com/bflad/tfproviderlint"
   version "0.27.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the bflad/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/bflad/homebrew-tap/Formula/tfproviderlint.rb:9
```